### PR TITLE
JananeseMovieの命名規則に合わせて、1つのインスタンスが１つのmovieを指すように変更

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/main/java/org/example/JapaneseBestMovie.java
+++ b/src/main/java/org/example/JapaneseBestMovie.java
@@ -1,6 +1,7 @@
 package org.example;
 
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class JapaneseBestMovie extends JapaneseMovie {
@@ -8,8 +9,18 @@ public class JapaneseBestMovie extends JapaneseMovie {
   String maxKey = null;
   Double maxValue = 0.0;
 
+  public JapaneseBestMovie(String movieName, Double movieReviewRating) {
+    super(movieName, movieReviewRating);
+  }
+
   public Map<String, Double> reviewMap() {
-    for (Map.Entry<String, Double> entry : super.movieReviewMap.entrySet()) {
+    Map<String, Double> movieReviewMap = new HashMap<>();
+    movieReviewMap.put(movie1.movieName, movie1.movieReviewRating);
+    movieReviewMap.put(movie2.movieName, movie2.movieReviewRating);
+    movieReviewMap.put(movie3.movieName, movie3.movieReviewRating);
+    movieReviewMap.put(movie4.movieName, movie4.movieReviewRating);
+    movieReviewMap.put(movie5.movieName, movie5.movieReviewRating);
+    for (Map.Entry<String, Double> entry : movieReviewMap.entrySet()) {
       if (entry.getValue() > maxValue) {
         maxKey = entry.getKey();
         maxValue = entry.getValue();

--- a/src/main/java/org/example/JapaneseMovie.java
+++ b/src/main/java/org/example/JapaneseMovie.java
@@ -1,13 +1,31 @@
 package org.example;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class JapaneseMovie implements Checking {
 
-  public Map<String, Double> movieReviewMap = Map.of("SLAMDUNK", 4.3, "千と千尋の神隠し", 4.1,
-      "22年目の告白私が殺人犯です", 3.6, "怒り", 3.9, "横道世之介", 3.9);
+  public String movieName;
+  public double movieReviewRating;
+
+  public JapaneseMovie(String movieName, Double movieReviewRating) {
+    this.movieName = movieName;
+    this.movieReviewRating = movieReviewRating;
+  }
+
+  JapaneseMovie movie1 = new JapaneseMovie("SLAMDUNK", 4.3);
+  JapaneseMovie movie2 = new JapaneseMovie("千と千尋の神隠し", 4.1);
+  JapaneseMovie movie3 = new JapaneseMovie("22年目の告白私が殺人犯です", 3.6);
+  JapaneseMovie movie4 = new JapaneseMovie("怒り", 3.9);
+  JapaneseMovie movie5 = new JapaneseMovie("横道世之介", 3.9);
 
   public Map<String, Double> reviewMap() {
+    Map<String, Double> movieReviewMap = new HashMap<>();
+    movieReviewMap.put(movie1.movieName, movie1.movieReviewRating);
+    movieReviewMap.put(movie2.movieName, movie2.movieReviewRating);
+    movieReviewMap.put(movie3.movieName, movie3.movieReviewRating);
+    movieReviewMap.put(movie4.movieName, movie4.movieReviewRating);
+    movieReviewMap.put(movie5.movieName, movie5.movieReviewRating);
     movieReviewMap.entrySet().stream()
         .filter(entry -> entry.getValue() >= 4.0)
         .map(entry -> "タイトル:" + entry.getKey() + "　評価数：" + entry.getValue())


### PR DESCRIPTION
JapanaseMovieクラスのmovie1~5のインスタンスがそれぞれの映画の情報を持つように変更しました。ただ、JapaneseMovieクラス内でコンストラクタを活用した関係で、JapaneseMovieクラスの引数の型が定義されてしまい、mainクラスでインスタンス生成できない状況になっています。
どうにかインスタンス生成して、エラーを外したいんですが、調べてもいまいちこの場合の対処方法に合致するものがありません。

質問：
今場合の対象方法を教えていただけないでしょうか。
コンストラクタを使用する際、配列はmainクラスに置く以外したことがなかったのですが、そもそもこれがよくないでしょうか。
また、Akamatsuさんにレヴューいただいた、「JapaneseMovieの一つのインスタンスが一つのmovieを指すのが自然かなと思います！」ということに関しては、私の訂正はレヴュー内容に沿っていますでしょうか。

調べたこと：
・コンストラクタはクラス名と同じ名前を持つ
・インスタンスが作られる時には必ず実行される
・コンストラクタのアクセス修飾子を変えることでインスタンスを作る範囲を制限する。
protected：同じパッケージ、あるは継承先のクラスだけから呼び出せる状態に変えること。ただ、結局インスタンス生成する際には、必ず実行されるものであるため意味がない？？

![スクリーンショット 2024-08-25 162917](https://github.com/user-attachments/assets/82b7cbd4-d835-4141-8bc6-5387ad8d3b5c)
